### PR TITLE
debug - fixing collisions with wall

### DIFF
--- a/collision.lua
+++ b/collision.lua
@@ -41,22 +41,22 @@ end
 
 
 function isNextSideWall(pObject, vx, vy)
-    local sideX = pObject.x + vx * (pObject.width * .5 + 2)
+    local sideX = pObject.x + vx * (pObject.width *.5 + 2)
     local sideY =  pObject.y + vy * (pObject.height * .5 + 2)
     local corner1 = { -- vx = 1 | vy = 0
         x = sideX + vy * pObject.width * .5, -- x = sideX
-        y = sideY + vx * pObject.height * .5 -- y = sideY + height/2
+        y = sideY + vx * pObject.height * .5 -- y = sideY + hitbox/2
     }
     local corner2 = {
         x = sideX - vy * pObject.width * .5, -- x = sideX
-        y = sideY - vx * pObject.height * .5 -- y = sideY - height/2
+        y = sideY - vx * pObject.height * .5 -- y = sideY - hitbox/2
     }
     local tX1, tY1 = getTileIndexes(corner1.x, corner1.y)
     local tX2, tY2 = getTileIndexes(corner2.x, corner2.y)
-    if map0Data[tY1] and map0Data[tY1][tX1] ~= 2 and map0Data[tY1] and map0Data[tY1][tX1] ~= 3 and map0Data[tY1] and map0Data[tY1][tX1] ~= 12 then
+    if map0Data[tY1] and map0Data[tY1][tX1]  ~=2 and map0Data[tY1] and map0Data[tY1][tX1] ~= 3 and map0Data[tY1] and map0Data[tY1][tX1] ~= 12 then
         return true
     end
-    if map0Data[tY1] and map0Data[tY1][tX1] ~= 2 and map0Data[tY1] and map0Data[tY1][tX1] ~= 3 and map0Data[tY1] and map0Data[tY1][tX1] ~= 12 then
+    if map0Data[tY2] and map0Data[tY2][tX2] ~= 2 and map0Data[tY2] and map0Data[tY2][tX2] ~= 3 and map0Data[tY2] and map0Data[tY2][tX2] ~= 12 then
         return true
     end
     return false

--- a/hero.lua
+++ b/hero.lua
@@ -63,8 +63,8 @@ end
 
 function hero.load()
     hero.sprite = love.graphics.newImage("sprites/hero.png")
-    hero.x = love.graphics.getWidth()/2 - 32
-    hero.y = love.graphics.getHeight()/2 - 32
+    hero.x = love.graphics.getWidth()/2 - 16
+    hero.y = love.graphics.getHeight()/2 - 16
     hero.sizeX = 32
     hero.sizeY = 32
     hero.width = hero.sprite:getWidth()
@@ -136,6 +136,7 @@ function hero:draw()
     love.graphics.draw(hero.sprite, hero.x, hero.y, hero.rotation, 1 , 1 , hero.width/2, hero.height/2)
     love.graphics.setColor(1, 1, 1, 1)
     love.graphics.print(hero.life, 100, 100, 0, 3, 3)
+    love.graphics.circle("line", hero.x, hero.y, hero.hitbox)
 end
 
 function hero.init()

--- a/level0/map_0.lua
+++ b/level0/map_0.lua
@@ -67,7 +67,7 @@ function map0:load()
     map0.height = (map0.tileSize * map0.col) 
     map0.posX = love.graphics.getWidth()/2 - map0.width/2 +map0.tileSize * 4
     map0.posY = love.graphics.getHeight()/2 - map0.height/2 + map0.tileSize * 4
-    map0.hitbox = 32
+    map0.hitbox = 64
 end
 
 
@@ -81,6 +81,7 @@ function map0:draw()
         for x = 1, #map0Data[y] do
             if map0Data[y][x] == 1 then
                 love.graphics.draw(map0.t1, map0.posX + (x * map0.tileSize), map0.posY + (y * map0.tileSize), 0, 4, 4)
+                love.graphics.rectangle("line", map0.posX + (x * map0.tileSize), map0.posY + (y * map0.tileSize), map0.tileSize, map0.tileSize)
             elseif map0Data[y][x] == 2 then
                 love.graphics.draw(map0.t2, map0.posX + (x * map0.tileSize), map0.posY + (y * map0.tileSize), 0, 4, 4)
             elseif map0Data[y][x] == 3 then

--- a/scenes/pause.lua
+++ b/scenes/pause.lua
@@ -1,7 +1,7 @@
 pause = {}
 
 function pause.draw()
-    map.draw()
+    map0.draw()
     hero.draw()
     if #ennemies > 0 then
         for _, e in ipairs(ennemies) do


### PR DESCRIPTION
explanation : 

just a bad typo in the wall collision check function inside collision.lua 

The function checks the four corners of the player sprite. However, after adding the new IDs for wall and fence tiles in map0, I forgot to update the check for all four corners — so the function now only verifies two corners, which makes it easy to go out of bounds.

I changed everything so the code runs fine. The bug is fixed.